### PR TITLE
Update idena-manager (add description for listen ports)

### DIFF
--- a/idena-manager/idena-manager
+++ b/idena-manager/idena-manager
@@ -1224,7 +1224,7 @@ generate_configs()
 			fi
 		fi
 
-		success_notification "For Node $id please enable inbound traffic for $listen_port port on the firewall."
+		success_notification "For Node $id please enable inbound traffic for $listen_port, $ipfs_port port on the firewall."
 		# shellcheck disable=SC2140
 		success_notification "When connecting your Idena client to Node $id, use $rpc_port port for tunneling, and "\
 "\"$api_key\" as your API key."


### PR DESCRIPTION
Привет, Rioda! Я напишу по-русски, если надо, переведу на английский. idena-manager после генерации конфига пишет, что "For Node 1 please enable inbound traffic for 40404 port on the firewall." Я так и сделал, но после проверки прослушиваемых портов (ss -tl) увидел, что никто не слушает порт 40404, зато слушают порт 40405, но я его не открывал. Соответственно, пиров получается мало, т.е. у меня максимум было 5, а иногда они совсем пропадали. Зато, когда я открыл порт 40405, пиров стало 18! И они уже никогда не обнулялись. Поэтому я предлагаю исправить сообщение о портах, которые нужно открыть, добавив в них порт от IPFS, потому что его-то точно нужно слушать. Предполагаю, что подобная проблема может быть и в Windows клиенте.